### PR TITLE
feat: implement two-repository architecture

### DIFF
--- a/.github/workflows/api-ci-cd.yml
+++ b/.github/workflows/api-ci-cd.yml
@@ -75,6 +75,13 @@ jobs:
           path: c2m-api-v2-security
           token: ${{ secrets.SECURITY_REPO_TOKEN }}
 
+      - name: Checkout artifacts repository
+        uses: actions/checkout@v4
+        with:
+          repository: faserrao/c2m-api-artifacts
+          path: artifacts-repo
+          token: ${{ secrets.SECURITY_REPO_TOKEN }}
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -159,6 +166,12 @@ jobs:
           echo "📚 Building API documentation..."
           make docs
 
+      - name: Generate SDKs
+        continue-on-error: true
+        run: |
+          echo "🔧 Generating SDKs..."
+          make generate-sdk-all || echo "⚠️  SDK generation not fully implemented yet"
+
       # ---------- Drift Detection (PRs only) ----------
       - name: Check for uncommitted changes
         if: github.event_name == 'pull_request'
@@ -215,18 +228,63 @@ jobs:
             POSTMAN_TARGET=$POSTMAN_TARGET make postman-publish
           fi
 
-      # ---------- Commit generated artifacts (main only) ----------
-      - name: Commit generated artifacts
+      # ---------- Copy artifacts to artifacts repo ----------
+      - name: Copy artifacts to artifacts repository
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "chore(ci): update OpenAPI spec, Postman collection, and docs"
-          commit_user_name: c2m-api-bot
-          commit_user_email: c2m-api-bot@users.noreply.github.com
-          file_pattern: |
-            ${{ env.OPENAPI_DIR }}/**
-            ${{ env.POSTMAN_DIR }}/generated/**
-            ${{ env.DOCS_DIR }}/**
+        run: |
+          echo "📦 Copying artifacts to artifacts repository..."
+          # Create directories if they don't exist
+          mkdir -p artifacts-repo/openapi
+          mkdir -p artifacts-repo/postman/collections
+          mkdir -p artifacts-repo/postman/metadata
+          mkdir -p artifacts-repo/docs
+          mkdir -p artifacts-repo/sdks
+          
+          # Copy OpenAPI specs
+          cp -v ${{ env.OPENAPI_DIR }}/*.yaml artifacts-repo/openapi/ 2>/dev/null || echo "No OpenAPI specs to copy"
+          
+          # Copy Postman collections
+          cp -v ${{ env.POSTMAN_DIR }}/generated/*.json artifacts-repo/postman/collections/ 2>/dev/null || echo "No collections to copy"
+          
+          # Copy Postman metadata
+          cp -v ${{ env.POSTMAN_DIR }}/*.txt artifacts-repo/postman/metadata/ 2>/dev/null || echo "No txt files to copy"
+          cp -v ${{ env.POSTMAN_DIR }}/*.json artifacts-repo/postman/metadata/ 2>/dev/null || echo "No json files to copy"
+          
+          # Copy documentation
+          cp -rv ${{ env.DOCS_DIR }}/* artifacts-repo/docs/ 2>/dev/null || echo "No docs to copy"
+          
+          # Copy SDKs if they exist
+          if [ -d "sdk" ]; then
+            cp -rv sdk/* artifacts-repo/sdks/ 2>/dev/null || echo "No SDKs to copy"
+          fi
+          
+          echo "✅ Artifacts copied successfully"
+
+      # ---------- Commit and push to artifacts repo ----------
+      - name: Commit and push artifacts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        working-directory: artifacts-repo
+        run: |
+          git config user.name "c2m-api-bot"
+          git config user.email "c2m-api-bot@users.noreply.github.com"
+          
+          # Add all changes
+          git add .
+          
+          # Create commit message with build info
+          COMMIT_MSG="Build #${{ github.run_number }}: Update from ${{ github.event.head_commit.message }}"
+          COMMIT_DESC="Source commit: ${{ github.sha }}
+          Workflow: ${{ github.workflow }}
+          Triggered by: ${{ github.actor }}"
+          
+          # Commit (don't fail if no changes)
+          git commit -m "$COMMIT_MSG" -m "$COMMIT_DESC" || {
+            echo "No changes to commit"
+            exit 0
+          }
+          
+          # Push to artifacts repo
+          git push origin main
 
       # ---------- Upload artifacts ----------
       - name: Upload build artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,38 @@ prism_test_body.json
 *_id.txt
 *_url.txt
 *_pid.txt
+
+# Generated artifacts (now in c2m-api-artifacts repo)
+# =============================================
+
+# Generated OpenAPI specifications
+/openapi/c2mapiv2-openapi-spec-base.yaml
+/openapi/c2mapiv2-openapi-spec-final.yaml
+/openapi/bundled.yaml
+/openapi/c2mapiv2-openapi-spec-final-with-examples.yaml
+
+# Generated Postman files
+/postman/generated/
+/postman/*.json
+/postman/env-upload-debug.json
+/postman/import-api-debug.json
+/postman/import-api-response.json
+/postman/link-debug.json
+/postman/link-payload.json
+/postman/mock-env.json
+/postman/postman_*.txt
+/postman/spec-standalone-*.json
+/postman/upload-test-debug.json
+
+# Generated documentation
+/docs/index.html
+/docs/site/
+/docs/swagger/
+/docs/redoc/
+
+# Generated SDKs
+/sdk/
+/sdks/
+
+# Temporary artifacts repo location
+/temp-artifacts/

--- a/user-guides/TWO_REPO_ARCHITECTURE.md
+++ b/user-guides/TWO_REPO_ARCHITECTURE.md
@@ -1,0 +1,398 @@
+# Two Repository Architecture for C2M API
+
+## 1. The Issue We're Solving
+
+### Current Problems:
+- **Race Conditions**: Multiple automated processes (CI/CD, Redoc updater) create git conflicts when trying to commit generated files
+- **Repository Bloat**: Generated files mixed with source files makes the repo large and noisy
+- **Unclear Ownership**: Hard to distinguish human-authored files from machine-generated ones
+- **Version Control Noise**: Every build creates commits with hundreds of generated file changes
+- **CI/CD Failures**: Builds succeed but fail to commit artifacts due to branch divergence
+
+### Root Cause:
+The single repository serves two conflicting purposes:
+1. **Source Control**: Managing human-authored source files
+2. **Artifact Storage**: Storing machine-generated build outputs
+
+## 2. How We're Solving It
+
+### Solution: Two-Repository Pattern
+Separate source files and generated artifacts into two distinct repositories:
+- **Source Repository**: Contains only human-authored files (EBNF, scripts, configs)
+- **Artifacts Repository**: Contains only machine-generated files (OpenAPI specs, SDKs, docs)
+
+### Benefits:
+- No more git conflicts between automated processes
+- Clear separation of concerns
+- Smaller, focused repositories
+- Clean commit history in source repo
+- CI/CD can always push to artifacts repo without conflicts
+
+## 3. Repository Descriptions
+
+### Source Repository: `c2m-api-repo`
+**Purpose**: Source of truth for API definitions and build logic
+
+**Contents**:
+```
+c2m-api-repo/
+├── data_dictionary/
+│   ├── c2mapiv2-dd.ebnf              # EBNF data dictionary (source of truth)
+│   └── examples/                      # Example requests/responses
+│
+├── scripts/
+│   ├── active/                        # Current conversion scripts
+│   │   ├── ebnf_to_openapi_dynamic_v3.py
+│   │   ├── merge_openapi_overlays.py
+│   │   └── ...
+│   └── utilities/                     # Helper scripts
+│
+├── openapi/
+│   └── overlays/                      # Only overlay files (human-authored)
+│       └── auth.tokens.yaml           # Auth endpoint additions
+│
+├── postman/
+│   ├── templates/                     # Postman collection templates
+│   └── scripts/                       # Pre-request scripts, tests
+│
+├── .github/
+│   └── workflows/                     # GitHub Actions workflows
+│       └── api-ci-cd.yml             # Main CI/CD pipeline
+│
+├── Makefile                          # Build orchestration
+├── requirements.txt                  # Python dependencies
+├── package.json                      # Node dependencies
+└── user-guides/                      # Documentation
+```
+
+### Artifacts Repository: `c2m-api-artifacts`
+**Purpose**: Storage for all generated build outputs
+
+**Contents**:
+```
+c2m-api-artifacts/
+├── openapi/
+│   ├── c2mapiv2-openapi-spec-base.yaml    # Generated from EBNF
+│   ├── c2mapiv2-openapi-spec-final.yaml   # With overlays applied
+│   └── bundled.yaml                        # Dereferenced version
+│
+├── postman/
+│   ├── collections/
+│   │   ├── c2mapiv2-collection.json
+│   │   ├── c2mapiv2-linked-collection-flat.json
+│   │   ├── c2mapiv2-test-collection.json
+│   │   └── ...
+│   │
+│   └── metadata/                           # Postman IDs, URLs
+│       ├── postman_mock_url.txt
+│       ├── postman_api_uid.txt
+│       ├── postman_env_uid.txt
+│       └── ...
+│
+├── docs/
+│   ├── redoc/
+│   │   └── index.html                      # Redoc API documentation
+│   ├── swagger/
+│   │   └── index.html                      # Swagger UI
+│   └── site/                               # GitHub Pages content
+│
+├── sdks/                                   # Generated SDKs
+│   ├── python/
+│   │   └── c2m_api_client/
+│   ├── javascript/
+│   │   └── c2m-api-client/
+│   ├── typescript/
+│   │   └── c2m-api-client/
+│   ├── java/
+│   │   └── com.c2m.api/
+│   ├── go/
+│   │   └── c2mapiclient/
+│   ├── csharp/
+│   │   └── C2M.Api.Client/
+│   └── ...
+│
+├── schemas/                                # JSON schemas (future)
+│   └── ...
+│
+└── README.md                               # Explains this is auto-generated
+```
+
+## 4. Key Differences Between Repositories
+
+| Aspect | Source Repo | Artifacts Repo |
+|--------|-------------|----------------|
+| **Authors** | Humans | CI/CD only |
+| **Edit Frequency** | When requirements change | Every build |
+| **File Types** | .ebnf, .py, .yml, .md | .yaml, .json, .html |
+| **Version Control** | Meaningful commits | Auto-commits |
+| **Size** | Small (~1-5 MB) | Large (~50+ MB) |
+| **Dependencies** | Yes (Python, Node) | No |
+| **CI/CD Role** | Trigger builds | Receive outputs |
+| **Permissions** | Team write access | CI write, team read |
+
+## 5. GitHub Actions Workflow
+
+### Trigger Events:
+1. Push to `main` branch in source repo
+2. Pull request to `main` branch  
+3. Manual workflow dispatch
+4. Scheduled runs (optional)
+
+### Workflow Steps:
+
+```yaml
+name: API Build and Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data_dictionary/**'
+      - 'scripts/**'
+      - 'openapi/overlays/**'
+      - 'Makefile'
+
+jobs:
+  build-and-deploy:
+    steps:
+      1. Checkout source repo (c2m-api-repo)
+      2. Checkout artifacts repo (c2m-api-artifacts)
+      3. Setup Python/Node environments
+      4. Install dependencies
+      
+      5. Generate artifacts:
+         - Run EBNF → OpenAPI converter
+         - Apply overlays
+         - Generate Postman collections
+         - Build documentation
+         - Generate SDKs (all languages)
+         
+      6. Copy artifacts to artifacts repo:
+         - openapi/* → artifacts-repo/openapi/
+         - postman/generated/* → artifacts-repo/postman/collections/
+         - docs/* → artifacts-repo/docs/
+         - sdk/* → artifacts-repo/sdks/
+         
+      7. Publish to Postman (both workspaces):
+         - Delete existing APIs/collections
+         - Import new OpenAPI spec
+         - Create linked collections
+         - Update mock servers
+         
+      8. Commit to artifacts repo:
+         - git add all changes
+         - Commit with build metadata
+         - Push to main branch
+         
+      9. Deploy GitHub Pages (from artifacts repo)
+```
+
+### Key Improvements:
+- No conflicts: CI is the only writer to artifacts repo
+- Atomic updates: All artifacts updated together
+- Clear audit trail: Each build creates one commit in artifacts repo
+- Parallel operations: Can update Postman while committing artifacts
+
+## 6. Steady State After a Successful Run
+
+### Source Repository State:
+- **No changes**: Source files remain unchanged
+- **Clean working tree**: No generated files to commit
+- **Build logs**: Available in GitHub Actions
+
+### Artifacts Repository State:
+- **Latest commit**: "Build #123: Update from EBNF changes"
+- **All artifacts synchronized**:
+  - OpenAPI specs match current EBNF
+  - Postman collections match OpenAPI specs
+  - Documentation reflects latest API
+- **Consistent timestamps**: All files updated together
+- **Tagged releases**: Optional versioning (v1.2.3)
+
+### Postman Workspaces State:
+- **Personal Workspace**: Updated with latest API/collections
+- **Team Workspace**: Updated with latest API/collections
+- **Mock Servers**: Running with latest specifications
+- **Environment Variables**: Updated with new mock URLs
+
+### GitHub Pages State:
+- **Deployed from artifacts repo**
+- **Latest documentation live**
+- **Accessible at**: https://faserrao.github.io/c2m-api-artifacts/
+
+## 7. Additional Considerations
+
+### Security:
+- **Secrets Required**:
+  - `SECURITY_REPO_TOKEN` (or new PAT) for artifacts repo access
+  - `POSTMAN_SERRAO_API_KEY` for personal workspace
+  - `POSTMAN_C2M_API_KEY` for team workspace
+- **Permissions**: 
+  - Source repo: Team has write access
+  - Artifacts repo: Team has read access, CI has write
+
+### Local Development: Detailed Workflows
+
+#### Current vs New Behavior
+
+| Action | Current (Single Repo) | New (Two Repo) |
+|--------|----------------------|----------------|
+| `make openapi-build` | Creates files, stages for commit | Creates files, they're gitignored |
+| `make postman-publish` | Updates Postman + commits files | Updates Postman only |
+| `git commit` | Includes generated files | Only source files |
+| View artifacts | In same repo | Need to check artifacts repo |
+
+#### Workflow 1: Quick Local Development (Most Common)
+For testing changes locally without publishing:
+
+```bash
+cd c2m-api-repo
+
+# Edit your EBNF file
+vim data_dictionary/c2mapiv2-dd.ebnf
+
+# Build and test locally
+make openapi-build              # Generates openapi/*.yaml
+make postman-collection-build   # Generates postman/generated/*
+make docs-build                 # Generates docs/*
+make generate-sdk-python        # Generates sdk/python/*
+
+# View your generated files
+cat openapi/c2mapiv2-openapi-spec-final.yaml
+open docs/index.html
+
+# IMPORTANT: These files are .gitignored
+# They exist locally but won't be committed to source repo
+```
+
+#### Workflow 2: Test Full Pipeline Locally
+Simulate the complete CI/CD process:
+
+```bash
+# Have both repos side by side
+~/projects/
+  ├── c2m-api-repo/        # Source files
+  └── c2m-api-artifacts/   # Generated files
+
+# Build in source repo
+cd ~/projects/c2m-api-repo
+make openapi-build
+make generate-sdk-all
+
+# Manually sync to artifacts repo
+cp -r openapi/*.yaml ../c2m-api-artifacts/openapi/
+cp -r sdk/* ../c2m-api-artifacts/sdks/
+
+# Commit to artifacts repo (simulating CI)
+cd ../c2m-api-artifacts
+git add .
+git commit -m "Local build test"
+```
+
+#### Workflow 3: Local Postman Updates
+Update Postman from local build without git:
+
+```bash
+cd c2m-api-repo
+
+# Build locally
+make openapi-build
+
+# Publish to Postman directly (without git commits)
+make postman-publish
+
+# This updates Postman but doesn't touch git at all
+# Perfect for testing before pushing to GitHub
+```
+
+#### New Make Targets for Local Development
+Add these targets to simplify local workflows:
+
+```makefile
+# Variables
+ARTIFACTS_REPO ?= ../c2m-api-artifacts
+
+# Sync local build to artifacts repo
+local-sync:
+    @echo "Syncing to local artifacts repo..."
+    @mkdir -p $(ARTIFACTS_REPO)/openapi
+    @mkdir -p $(ARTIFACTS_REPO)/postman/collections
+    @mkdir -p $(ARTIFACTS_REPO)/docs
+    @mkdir -p $(ARTIFACTS_REPO)/sdks
+    cp -r openapi/*.yaml $(ARTIFACTS_REPO)/openapi/
+    cp -r postman/generated/* $(ARTIFACTS_REPO)/postman/collections/
+    cp -r docs/* $(ARTIFACTS_REPO)/docs/
+    cp -r sdk/* $(ARTIFACTS_REPO)/sdks/
+
+# Build everything and sync
+local-full-build: openapi-build docs-build generate-sdk-all local-sync
+    @echo "Full build complete and synced!"
+
+# Test the complete pipeline locally
+local-test-pipeline:
+    make local-full-build
+    cd $(ARTIFACTS_REPO) && git add . && git commit -m "Local test"
+    @echo "Pipeline test complete!"
+```
+
+#### Benefits for Local Development
+
+1. **Faster commits** - No huge generated files in your commits
+2. **Cleaner diffs** - Only see actual source changes  
+3. **Flexible testing** - Can test locally without affecting git
+4. **Parallel work** - Can work on source while CI handles artifacts
+5. **Quick iteration** - Test changes without waiting for CI/CD
+
+#### Required .gitignore Updates
+
+```gitignore
+# Generated OpenAPI specs
+/openapi/c2mapiv2-openapi-spec-base.yaml
+/openapi/c2mapiv2-openapi-spec-final.yaml
+/openapi/bundled.yaml
+
+# Generated Postman files
+/postman/generated/
+/postman/*.json
+/postman/*.txt
+
+# Generated documentation
+/docs/index.html
+/docs/site/
+/docs/swagger/
+
+# Generated SDKs
+/sdk/
+```
+
+This ensures generated files stay local and don't clutter the repository.
+
+### Rollback Strategy:
+- Source repo: Revert commit and rebuild
+- Artifacts repo: Check out previous commit or use GitHub releases
+- Postman: Keep previous version as backup collection
+
+### Monitoring:
+- GitHub Actions notifications for build failures
+- Postman monitors for API health
+- Optional: Webhook notifications for artifact updates
+
+### Future Enhancements:
+1. **Semantic Versioning**: Tag releases in artifacts repo
+2. **SDK Publishing**: Publish SDKs to package managers (PyPI, npm, Maven)
+3. **Change Detection**: Only rebuild changed components
+4. **Multi-environment**: Support dev/staging/prod artifacts
+5. **Artifact Retention**: Automated cleanup of old builds
+6. **SDK Documentation**: Generate SDK-specific docs and examples
+
+## 8. Migration Plan
+
+1. Create artifacts repository
+2. Update CI/CD workflow
+3. Test with a small change
+4. Remove generated files from source repo
+5. Update documentation and team processes
+
+## Conclusion
+
+This two-repository architecture provides a clean separation between source and generated files, eliminates CI/CD conflicts, and creates a more maintainable system. The source repository remains focused on human-authored content while the artifacts repository serves as a reliable distribution point for all generated assets.

--- a/user-guides/TWO_REPO_IMPLEMENTATION_PLAN.md
+++ b/user-guides/TWO_REPO_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,384 @@
+# Two Repository Implementation Plan
+
+## Overview
+This document provides a step-by-step plan to migrate from the current single-repository structure to a two-repository architecture, separating source files from generated artifacts.
+
+## Phase 1: Create Artifacts Repository
+
+### Task 1.1: Create New GitHub Repository
+**Owner**: Repository Admin
+**Description**: Create the new artifacts repository on GitHub
+**Steps**:
+```bash
+gh repo create faserrao/c2m-api-artifacts \
+  --public \
+  --description "Generated artifacts from c2m-api-repo builds" \
+  --add-readme
+```
+
+### Task 1.2: Initialize Artifacts Repository Structure
+**Owner**: Developer
+**Description**: Create the initial directory structure
+**Steps**:
+```bash
+git clone https://github.com/faserrao/c2m-api-artifacts.git
+cd c2m-api-artifacts
+
+# Create directory structure
+mkdir -p openapi
+mkdir -p postman/collections
+mkdir -p postman/metadata
+mkdir -p docs/redoc
+mkdir -p docs/swagger
+mkdir -p sdks
+
+# Create README
+cat > README.md << 'EOF'
+# C2M API Artifacts
+
+This repository contains automatically generated artifacts from the [c2m-api-repo](https://github.com/faserrao/c2m-api-repo).
+
+## ⚠️ Do Not Edit These Files
+
+All files in this repository are automatically generated. Any manual changes will be overwritten by the next build.
+
+To make changes, please edit the source files in [c2m-api-repo](https://github.com/faserrao/c2m-api-repo).
+
+## Repository Structure
+
+- `openapi/` - Generated OpenAPI specifications
+- `postman/` - Postman collections and metadata
+- `docs/` - API documentation
+- `sdks/` - Generated client SDKs
+
+## Build Status
+
+Latest build: See [GitHub Actions](https://github.com/faserrao/c2m-api-repo/actions)
+EOF
+
+# Initial commit
+git add .
+git commit -m "Initial repository structure"
+git push origin main
+```
+
+### Task 1.3: Configure GitHub Pages (Optional)
+**Owner**: Repository Admin
+**Description**: Enable GitHub Pages for documentation hosting
+**Steps**:
+1. Go to Settings → Pages
+2. Source: Deploy from branch
+3. Branch: main
+4. Folder: /docs
+5. Save
+
+## Phase 2: Update Source Repository
+
+### Task 2.1: Create/Update .gitignore
+**Owner**: Developer
+**Description**: Add generated files to .gitignore
+**File**: `.gitignore`
+```gitignore
+# Generated OpenAPI specifications
+/openapi/c2mapiv2-openapi-spec-base.yaml
+/openapi/c2mapiv2-openapi-spec-final.yaml
+/openapi/bundled.yaml
+/openapi/c2mapiv2-openapi-spec-final-with-examples.yaml
+
+# Generated Postman files
+/postman/generated/
+/postman/*.json
+/postman/*.txt
+/postman/env-upload-debug.json
+/postman/import-api-debug.json
+/postman/import-api-response.json
+/postman/link-debug.json
+/postman/link-payload.json
+/postman/mock-env.json
+/postman/postman_*.txt
+/postman/spec-standalone-*.json
+/postman/upload-test-debug.json
+
+# Generated documentation
+/docs/index.html
+/docs/site/
+/docs/swagger/
+/docs/redoc/
+
+# Generated SDKs
+/sdk/
+/sdks/
+
+# Build artifacts
+*.pyc
+__pycache__/
+.venv/
+venv/
+node_modules/
+.DS_Store
+```
+
+### Task 2.2: Update GitHub Actions Workflow
+**Owner**: DevOps/Developer
+**Description**: Modify CI/CD to use two repositories
+**File**: `.github/workflows/api-ci-cd.yml`
+
+Key changes needed:
+```yaml
+jobs:
+  build:
+    steps:
+      # Add after existing checkout
+      - name: Checkout artifacts repository
+        uses: actions/checkout@v4
+        with:
+          repository: faserrao/c2m-api-artifacts
+          path: artifacts-repo
+          token: ${{ secrets.SECURITY_REPO_TOKEN }}
+      
+      # Replace the commit step with:
+      - name: Copy artifacts to artifacts repo
+        run: |
+          # Copy generated files
+          cp -r openapi/*.yaml artifacts-repo/openapi/
+          cp -r postman/generated/* artifacts-repo/postman/collections/
+          cp -r postman/*.txt artifacts-repo/postman/metadata/
+          cp -r postman/*.json artifacts-repo/postman/metadata/
+          cp -r docs/* artifacts-repo/docs/
+          if [ -d "sdk" ]; then cp -r sdk/* artifacts-repo/sdks/; fi
+          
+      - name: Commit and push artifacts
+        working-directory: artifacts-repo
+        run: |
+          git config user.name "c2m-api-bot"
+          git config user.email "c2m-api-bot@users.noreply.github.com"
+          git add .
+          git commit -m "Build #${{ github.run_number }}: Update from ${{ github.sha }}" || echo "No changes"
+          git push
+```
+
+### Task 2.3: Add Local Development Make Targets
+**Owner**: Developer
+**Description**: Add convenience targets for local development
+**File**: `Makefile`
+
+Add these targets:
+```makefile
+# Two-repo local development support
+ARTIFACTS_REPO ?= ../c2m-api-artifacts
+
+.PHONY: local-sync
+local-sync: ## Sync generated files to local artifacts repo
+	@echo "📦 Syncing artifacts to $(ARTIFACTS_REPO)..."
+	@if [ ! -d "$(ARTIFACTS_REPO)" ]; then \
+		echo "❌ Artifacts repo not found at $(ARTIFACTS_REPO)"; \
+		echo "   Clone it with: git clone https://github.com/faserrao/c2m-api-artifacts.git $(ARTIFACTS_REPO)"; \
+		exit 1; \
+	fi
+	@mkdir -p $(ARTIFACTS_REPO)/openapi
+	@mkdir -p $(ARTIFACTS_REPO)/postman/collections
+	@mkdir -p $(ARTIFACTS_REPO)/postman/metadata
+	@mkdir -p $(ARTIFACTS_REPO)/docs
+	@mkdir -p $(ARTIFACTS_REPO)/sdks
+	@cp -v openapi/*.yaml $(ARTIFACTS_REPO)/openapi/ 2>/dev/null || true
+	@cp -v postman/generated/* $(ARTIFACTS_REPO)/postman/collections/ 2>/dev/null || true
+	@cp -v postman/*.txt postman/*.json $(ARTIFACTS_REPO)/postman/metadata/ 2>/dev/null || true
+	@cp -rv docs/* $(ARTIFACTS_REPO)/docs/ 2>/dev/null || true
+	@cp -rv sdk/* $(ARTIFACTS_REPO)/sdks/ 2>/dev/null || true
+	@echo "✅ Sync complete!"
+
+.PHONY: local-full-build
+local-full-build: openapi-build postman-collection-build docs-build ## Full build with artifacts sync
+	@$(MAKE) local-sync
+
+.PHONY: local-test-pipeline
+local-test-pipeline: ## Test the full two-repo pipeline locally
+	@echo "🧪 Testing full pipeline locally..."
+	@$(MAKE) clean
+	@$(MAKE) local-full-build
+	@cd $(ARTIFACTS_REPO) && \
+		git add . && \
+		git diff --staged --stat && \
+		echo "✅ Pipeline test complete! (Changes not committed)"
+```
+
+## Phase 3: Test Migration
+
+### Task 3.1: Test Local Builds
+**Owner**: Developer
+**Description**: Verify local development workflows
+**Steps**:
+```bash
+# Clone both repos
+git clone https://github.com/faserrao/c2m-api-repo.git
+git clone https://github.com/faserrao/c2m-api-artifacts.git
+
+# Test build and sync
+cd c2m-api-repo
+make local-full-build
+
+# Verify artifacts
+ls ../c2m-api-artifacts/openapi/
+ls ../c2m-api-artifacts/postman/collections/
+```
+
+### Task 3.2: Test CI/CD with Test Branch
+**Owner**: DevOps/Developer
+**Description**: Test the new workflow before deploying to main
+**Steps**:
+1. Create test branch: `git checkout -b test/two-repo-setup`
+2. Push changes and monitor GitHub Actions
+3. Verify artifacts are pushed to artifacts repo
+4. Verify Postman is still updated correctly
+
+### Task 3.3: Verify Postman Integration
+**Owner**: API Team
+**Description**: Ensure Postman workspaces still update correctly
+**Checklist**:
+- [ ] Personal workspace receives updates
+- [ ] Team workspace receives updates
+- [ ] Mock servers are created/updated
+- [ ] Collections are properly linked
+
+## Phase 4: Clean Up Source Repository
+
+### Task 4.1: Remove Generated Files
+**Owner**: Developer
+**Description**: Remove all generated files from source repo
+**Steps**:
+```bash
+# Remove generated files (they're now in artifacts repo)
+git rm -r openapi/c2mapiv2-openapi-spec-*.yaml
+git rm -r openapi/bundled.yaml
+git rm -r postman/generated/
+git rm postman/*.json
+git rm postman/*.txt
+git rm -rf docs/index.html docs/site/ docs/swagger/
+git rm -rf sdk/
+
+# Commit the removal
+git commit -m "chore: remove generated files (moved to artifacts repo)"
+```
+
+### Task 4.2: Update Documentation
+**Owner**: Developer
+**Description**: Update all documentation to reflect new structure
+**Files to update**:
+- [ ] README.md - Add links to artifacts repo
+- [ ] CONTRIBUTING.md - Update build instructions
+- [ ] user-guides/*.md - Update any build-related guides
+
+### Task 4.3: Update CI/CD Badges
+**Owner**: Developer
+**Description**: Add status badges to both repos
+**In source repo README**:
+```markdown
+[![Build Status](https://github.com/faserrao/c2m-api-repo/actions/workflows/api-ci-cd.yml/badge.svg)](https://github.com/faserrao/c2m-api-repo/actions)
+[![Artifacts](https://img.shields.io/badge/artifacts-c2m--api--artifacts-blue)](https://github.com/faserrao/c2m-api-artifacts)
+```
+
+## Phase 5: Deploy to Production
+
+### Task 5.1: Merge to Main Branch
+**Owner**: Repository Admin
+**Description**: Deploy the new workflow
+**Steps**:
+1. Create PR from test branch
+2. Review all changes
+3. Merge to main
+4. Monitor first production build
+
+### Task 5.2: Verify Production Build
+**Owner**: DevOps Team
+**Description**: Ensure everything works in production
+**Checklist**:
+- [ ] GitHub Actions completes successfully
+- [ ] Artifacts repo receives updates
+- [ ] Postman workspaces are updated
+- [ ] No git conflicts or errors
+
+### Task 5.3: Team Training
+**Owner**: Team Lead
+**Description**: Update team on new workflow
+**Topics**:
+- New repository structure
+- Local development changes
+- Where to find generated files
+- How to debug build issues
+
+## Phase 6: Post-Migration Tasks
+
+### Task 6.1: Set Up Monitoring
+**Owner**: DevOps
+**Description**: Monitor both repositories
+**Actions**:
+- Set up notifications for build failures
+- Monitor artifacts repo size
+- Set up alerts for Postman API failures
+
+### Task 6.2: Create Backup Strategy
+**Owner**: DevOps
+**Description**: Ensure artifacts are backed up
+**Options**:
+- GitHub releases for versioning
+- External backup of artifacts
+- Retention policy for old builds
+
+### Task 6.3: Document Rollback Procedure
+**Owner**: Developer
+**Description**: Create rollback documentation
+**Include**:
+- How to revert to single-repo if needed
+- How to restore from artifacts backup
+- Emergency contact procedures
+
+## Success Criteria
+
+The migration is complete when:
+
+1. ✅ Source repo contains only human-authored files
+2. ✅ Artifacts repo contains all generated files
+3. ✅ CI/CD builds without errors
+4. ✅ Postman workspaces update correctly
+5. ✅ Local development workflows are functional
+6. ✅ Team is trained on new process
+7. ✅ Documentation is updated
+8. ✅ No generated files in source repo git history going forward
+
+## Timeline Estimate
+
+- Phase 1: 1 hour (create and setup repos)
+- Phase 2: 2-3 hours (update workflows and test)
+- Phase 3: 1-2 hours (testing)
+- Phase 4: 1 hour (cleanup)
+- Phase 5: 1 hour (deployment)
+- Phase 6: 2 hours (monitoring and documentation)
+
+**Total**: 8-10 hours of work
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| CI/CD fails | Test thoroughly on branch first |
+| Postman stops updating | Keep existing workflow as fallback |
+| Team confusion | Document clearly, train early |
+| Lost artifacts | Implement backup strategy |
+| Git conflicts | Ensure only CI writes to artifacts |
+
+## Rollback Plan
+
+If issues arise:
+1. Revert GitHub Actions workflow
+2. Restore generated files to source repo
+3. Remove .gitignore entries
+4. Archive artifacts repo (don't delete)
+5. Document lessons learned
+
+## Notes
+
+- Keep the `SECURITY_REPO_TOKEN` secret (reuse for artifacts repo)
+- Consider renaming to `CROSS_REPO_TOKEN` later
+- The first build after migration will be large
+- Subsequent builds will be incremental
+- Consider setting up branch protection on artifacts repo (only CI can push to main)

--- a/user-guides/TWO_REPO_MIGRATION_LOG.md
+++ b/user-guides/TWO_REPO_MIGRATION_LOG.md
@@ -1,0 +1,286 @@
+# Two Repository Migration Log
+
+This document tracks the actual implementation of the two-repository migration for the C2M API project.
+
+## Migration Status Overview
+- **Started**: 2025-09-18 13:18 PST
+- **Current Phase**: Phase 1 Complete, Ready for Phase 2
+- **Source Repo**: `c2m-api-repo`
+- **Artifacts Repo**: `c2m-api-artifacts` (currently in temp-artifacts/)
+
+---
+
+## Phase 1: Create Artifacts Repository ✅ COMPLETE
+
+### Task 1.1: Create New GitHub Repository ✅
+**Completed**: 2025-09-18 13:18 PST
+
+**Actions Taken**:
+```bash
+gh repo create faserrao/c2m-api-artifacts --public --description "Generated artifacts from c2m-api-repo builds" --add-readme
+```
+
+**Result**: Repository already existed (created earlier at 2025-09-17T17:27:01Z)
+- URL: https://github.com/faserrao/c2m-api-artifacts
+- Visibility: Public
+- Description: "Generated artifacts from c2m-api-repo builds"
+
+### Task 1.2: Initialize Artifacts Repository Structure ✅
+**Completed**: 2025-09-18 13:20 PST
+
+**Actions Taken**:
+1. Cloned repository to temporary location:
+   ```bash
+   git clone https://github.com/faserrao/c2m-api-artifacts.git temp-artifacts
+   ```
+   Note: Cloned to `temp-artifacts/` within source repo due to directory access constraints
+
+2. Created directory structure:
+   ```bash
+   cd temp-artifacts
+   mkdir -p openapi postman/collections postman/metadata docs/redoc docs/swagger sdks
+   ```
+
+3. Created comprehensive README.md with:
+   - Warning about auto-generated files
+   - Repository structure documentation
+   - Usage instructions
+   - Links back to source repo
+
+4. Committed and pushed:
+   ```bash
+   git add .
+   git commit -m "Initial repository structure with directories and comprehensive README"
+   git push origin main
+   ```
+
+**Result**: 
+- Commit: 2079b6b
+- All directories created successfully
+- README provides clear documentation
+
+### Task 1.3: Configure GitHub Pages (Optional) ⏭️
+**Status**: Skipped (marked as optional)
+
+**Instructions for later**:
+1. Go to https://github.com/faserrao/c2m-api-artifacts/settings/pages
+2. Source: Deploy from a branch
+3. Branch: main
+4. Folder: /docs
+5. Save
+
+**Would enable**: https://faserrao.github.io/c2m-api-artifacts/
+
+### Phase 1 Verification ✅
+**Completed**: 2025-09-18 13:22 PST
+
+**Verified**:
+- ✅ Repository exists on GitHub
+- ✅ Directory structure is correct
+- ✅ README is comprehensive
+- ✅ Initial commit pushed successfully
+
+**Current Location**: 
+- Artifacts repo cloned to: `c2m-api-repo/temp-artifacts/`
+- Final location will be: `../c2m-api-artifacts/` (sibling to source repo)
+
+---
+
+## Phase 2: Update Source Repository 🔄 IN PROGRESS
+
+### Task 2.1: Create/Update .gitignore ✅
+**Status**: Completed 2025-09-18 13:30 PST
+
+**Actions Taken**:
+1. Checked existing .gitignore (159 lines)
+2. Added new section for generated artifacts:
+   - OpenAPI specifications (base, final, bundled)
+   - Postman generated files and metadata
+   - Documentation files
+   - SDK directories
+   - Temporary artifacts location
+
+**Entries Added**:
+```gitignore
+# Generated artifacts (now in c2m-api-artifacts repo)
+# =============================================
+
+# Generated OpenAPI specifications
+/openapi/c2mapiv2-openapi-spec-base.yaml
+/openapi/c2mapiv2-openapi-spec-final.yaml
+/openapi/bundled.yaml
+/openapi/c2mapiv2-openapi-spec-final-with-examples.yaml
+
+# Generated Postman files
+/postman/generated/
+/postman/*.json
+/postman/env-upload-debug.json
+[... and more]
+
+# Temporary artifacts repo location
+/temp-artifacts/
+```
+
+**Verification**:
+- ✅ Git status confirms temp-artifacts/ is ignored
+- ✅ Ready to commit when Phase 2 is complete
+
+### Task 2.2: Update GitHub Actions Workflow ✅
+**Status**: Completed 2025-09-18 13:35 PST
+**File**: .github/workflows/api-ci-cd.yml
+
+**Changes Made**:
+1. **Added artifacts repo checkout** (after security repo):
+   ```yaml
+   - name: Checkout artifacts repository
+     uses: actions/checkout@v4
+     with:
+       repository: faserrao/c2m-api-artifacts
+       path: artifacts-repo
+       token: ${{ secrets.SECURITY_REPO_TOKEN }}
+   ```
+
+2. **Added SDK generation step** (after docs build):
+   ```yaml
+   - name: Generate SDKs
+     continue-on-error: true
+     run: |
+       echo "🔧 Generating SDKs..."
+       make generate-sdk-all || echo "⚠️  SDK generation not fully implemented yet"
+   ```
+
+3. **Replaced commit step with two new steps**:
+   - Copy artifacts to artifacts repo (with directory creation)
+   - Commit and push to artifacts repo (with build metadata)
+
+**Key Features**:
+- Uses existing SECURITY_REPO_TOKEN for artifacts repo access
+- Creates directories if they don't exist
+- Copies all generated files (OpenAPI, Postman, docs, SDKs)
+- Includes build number and source commit in artifact commits
+- Doesn't fail if no changes to commit
+- Only runs on push to main branch
+
+### Task 2.3: Add Local Development Make Targets ✅
+**Status**: Completed 2025-09-18 13:38 PST
+**File**: Makefile
+
+**New Targets Added**:
+1. **`make local-sync`** - Sync generated files to local artifacts repo
+   - Checks if artifacts repo exists
+   - Creates all required directories
+   - Copies all generated files with verbose output
+   - Shows what was copied
+
+2. **`make local-full-build`** - Full build with artifacts sync
+   - Runs openapi-build
+   - Runs postman-collection-build
+   - Runs docs-build
+   - Runs generate-sdk-all (with fallback)
+   - Runs local-sync
+
+3. **`make local-test-pipeline`** - Test the full pipeline locally
+   - Cleans previous builds
+   - Runs full build
+   - Shows git diff in artifacts repo (without committing)
+
+4. **`make artifacts-status`** - Check artifacts repo status
+   - Shows location, branch, and git status
+   - Useful for debugging
+
+**Configuration**:
+- `ARTIFACTS_REPO` variable defaults to `../c2m-api-artifacts`
+- Can be overridden: `make local-sync ARTIFACTS_REPO=/custom/path`
+
+### Phase 2 Summary ✅
+**Completed**: 2025-09-18 13:38 PST
+
+**All Phase 2 tasks completed successfully**:
+1. ✅ Updated .gitignore to exclude generated files
+2. ✅ Modified GitHub Actions workflow for two-repo architecture
+3. ✅ Added Make targets for local development
+
+**Files Modified** (not yet committed):
+- `.gitignore` - Added generated artifact patterns
+- `.github/workflows/api-ci-cd.yml` - New artifact repo handling
+- `Makefile` - Four new local development targets
+
+**Ready for Testing**: Phase 2 changes are complete and ready to test
+
+---
+
+## Phase 3: Test Migration 🔄 IN PROGRESS
+
+### Task 3.1: Test Local Builds ✅
+**Status**: Completed 2025-09-18 13:43 PST
+
+**Tests Performed**:
+1. **Verified Make targets work**:
+   - `make artifacts-status ARTIFACTS_REPO=temp-artifacts` ✅
+   - `make openapi-build` ✅
+   - `make local-sync ARTIFACTS_REPO=temp-artifacts` ✅
+
+2. **Results**:
+   - OpenAPI spec built successfully (with paymentDetails as required!)
+   - All files synced to artifacts repo:
+     - 4 OpenAPI specs
+     - 7 Postman collections
+     - 20 Postman metadata files
+     - ~40 documentation files
+     - Full C# SDK
+
+3. **Verification**:
+   - Files are properly organized in subdirectories
+   - Verbose output shows exactly what's being copied
+   - No errors during sync
+
+### Task 3.2: Test CI/CD with Test Branch 🚧 IN PROGRESS
+**Status**: Started 2025-09-18 13:44 PST
+
+---
+
+## Phase 4: Clean Up Source Repository ⏳ NOT STARTED
+
+---
+
+## Phase 5: Deploy to Production ⏳ NOT STARTED
+
+---
+
+## Phase 6: Post-Migration Tasks ⏳ NOT STARTED
+
+---
+
+## Notes and Observations
+
+### Directory Access Limitation
+- Claude Code session started from source repo, limiting access to parent directories
+- Solution: Clone artifacts repo temporarily within source repo, move later
+- No impact on functionality, just requires manual move after setup
+
+### Repository Already Existed
+- The c2m-api-artifacts repo was created earlier (2025-09-17)
+- No issues, proceeded with initialization
+
+### Next Steps
+1. Proceed with Phase 2 to update source repository
+2. After all phases complete, manually move temp-artifacts to final location:
+   ```bash
+   mv temp-artifacts ../c2m-api-artifacts
+   ```
+
+---
+
+## Session Recovery Information
+
+If session is interrupted, current state:
+- Phase 1 is complete
+- Artifacts repo exists at: https://github.com/faserrao/c2m-api-artifacts
+- Local clone is at: `c2m-api-repo/temp-artifacts/`
+- Ready to start Phase 2 (updating source repo)
+- Next task: Create/update .gitignore in source repo
+
+Last command executed:
+```bash
+git push origin main  # In temp-artifacts directory
+```


### PR DESCRIPTION
## Summary
- Implements separation of source files and generated artifacts
- Updates CI/CD to push artifacts to c2m-api-artifacts repo
- Adds local development support with new Make targets

## Changes
- Updated .gitignore to exclude generated files
- Modified GitHub Actions workflow to use two repos
- Added 4 new Make targets for local development
- Created comprehensive documentation

## Testing
- Local builds tested with `make local-sync`
- This PR will test the CI/CD workflow

See user-guides/TWO_REPO_MIGRATION_LOG.md for detailed progress tracking.