### PR TITLE
Hotfix: Handle missing OpenAPI spec in main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -711,12 +711,15 @@ openapi-spec-diff:
 	@echo "📤 Fetching latest from origin/main…"
 	git fetch origin
 	@echo "🧾 Checking out previous version of spec for diff comparison…"
-	git show $(C2MAPIV2_MAIN_SPEC_PATH) > $(PREVIOUS_C2MAPIV2_OPENAPI_SPEC)
-	@echo "🔍 Running openapi-diff…"
-	# TODO: Fix hanging issue with npm version of openapi-diff
-	# Was working with brew version, but npm version hangs
-	# -$(OPENAPI_DIFF) $(PREVIOUS_C2MAPIV2_OPENAPI_SPEC) $(C2MAPIV2_OPENAPI_SPEC)
-	@echo "⚠️  openapi-diff temporarily disabled due to hanging issue"
+	# Check if the file exists in origin/main before trying to show it
+	@if git ls-tree -r origin/main --name-only | grep -q "^$(C2MAPIV2_OPENAPI_SPEC)$$"; then \
+		git show $(C2MAPIV2_MAIN_SPEC_PATH) > $(PREVIOUS_C2MAPIV2_OPENAPI_SPEC); \
+		echo "🔍 Running openapi-diff…"; \
+		echo "⚠️  openapi-diff temporarily disabled due to hanging issue"; \
+	else \
+		echo "ℹ️  No previous spec found in origin/main (this is normal for two-repo architecture)"; \
+		echo "✅ Skipping diff comparison"; \
+	fi
 
 # Clean up diff temporary files
 .PHONY: clean-openapi-spec-diff


### PR DESCRIPTION
## Summary
This PR fixes the CI/CD failure that occurred after merging the two-repository architecture changes.

## Problem
The `openapi-spec-diff` target in the Makefile was trying to checkout `openapi/c2mapiv2-openapi-spec-final.yaml` from `origin/main`, but that file no longer exists because we just removed all generated files in PR #48.

## Solution
- Updated the `openapi-spec-diff` target to check if the file exists before trying to show it
- If the file doesn't exist, it prints an informative message and skips the diff
- This allows the build to continue successfully

## Impact
- Fixes the immediate CI/CD failure on main branch
- Allows Postman publish to complete successfully
- This is a transition fix - once artifacts start being stored in the artifacts repo, we may want to update this to fetch from there instead